### PR TITLE
Inject at TAIL instead of overriding PlayerEntity.*CustomDataFromNBT

### DIFF
--- a/src/main/java/dev/hybridlabs/aquatic/interfaces/Porcupine.java
+++ b/src/main/java/dev/hybridlabs/aquatic/interfaces/Porcupine.java
@@ -5,7 +5,5 @@ import net.minecraft.item.ItemStack;
 import java.util.List;
 
 public interface Porcupine {
-
     List<ItemStack> hybrid_aquatic$getImpaledStacks();
-
 }

--- a/src/main/java/dev/hybridlabs/aquatic/mixin/PlayerEntityPorcupineMixin.java
+++ b/src/main/java/dev/hybridlabs/aquatic/mixin/PlayerEntityPorcupineMixin.java
@@ -1,5 +1,6 @@
 package dev.hybridlabs.aquatic.mixin;
 
+import dev.hybridlabs.aquatic.HybridAquatic;
 import dev.hybridlabs.aquatic.interfaces.Porcupine;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
@@ -21,48 +22,43 @@ import java.util.List;
 
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityPorcupineMixin extends LivingEntity implements Porcupine {
+    @Unique private final List<ItemStack> impaledStacks = new ArrayList<>();
+    @Unique private static final String IMPALED_ITEM_KEY = HybridAquatic.MOD_ID + ":impaled_items";
 
-    @Unique
-    List<ItemStack> impaledStacks = new ArrayList<>();
-    @Unique
-    private static final String IMPALED_ITEM_KEY = "impaled_items";
-
-    protected PlayerEntityPorcupineMixin(EntityType<? extends LivingEntity> entityType, World world) {
-        super(entityType, world);
+    private PlayerEntityPorcupineMixin(EntityType<? extends LivingEntity> type, World world) {
+        super(type, world);
     }
 
     /**
      * Get stacks currently impaled in player
      * @return immutable list of stacks within player
      */
-    @Unique
-    public List<ItemStack> hybrid_aquatic$getImpaledStacks() {
+    public @Unique List<ItemStack> hybrid_aquatic$getImpaledStacks() {
         return Collections.unmodifiableList(impaledStacks);
     }
-    @Inject( method="readCustomDataFromNbt", at=@At("TAIL") )
-    public void inject$readCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
+
+    @Inject(method = "readCustomDataFromNbt", at = @At("TAIL"))
+    public void onReadCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
         impaledStacks.clear();
 
         // Check if list exists, otherwise we're going to have issues.
         if (nbt.contains(IMPALED_ITEM_KEY, NbtElement.LIST_TYPE)) {
-            var list = nbt.getList(IMPALED_ITEM_KEY, NbtElement.COMPOUND_TYPE);
-
-            for (var item : list) if (item instanceof NbtCompound itemNBT) {
-                var stack = ItemStack.fromNbt(itemNBT);
+            NbtList list = nbt.getList(IMPALED_ITEM_KEY, NbtElement.COMPOUND_TYPE);
+            list.stream().map(NbtCompound.class::cast).forEach(stackNbt -> {
+                ItemStack stack = ItemStack.fromNbt(stackNbt);
                 impaledStacks.add(stack);
-            }
+            });
         }
     }
 
-    @Inject( method="writeCustomDataToNbt", at=@At("TAIL") )
-    public void writeCustomDataToNbt(NbtCompound nbt, CallbackInfo ci) {
-
+    @Inject(method = "writeCustomDataToNbt", at = @At("TAIL"))
+    public void onWriteCustomDataToNbt(NbtCompound nbt, CallbackInfo ci) {
         if (!impaledStacks.isEmpty()) {
-            var list = new NbtList();
-            for (var stack : impaledStacks) {
-                var writtenNBT = stack.writeNbt(new NbtCompound());
-                list.add(writtenNBT);
-            }
+            NbtList list = new NbtList();
+            impaledStacks.forEach(stack -> {
+                NbtCompound stackNbt = stack.writeNbt(new NbtCompound());
+                list.add(stackNbt);
+            });
             nbt.put(IMPALED_ITEM_KEY, list);
         }
     }

--- a/src/main/java/dev/hybridlabs/aquatic/mixin/PlayerEntityPorcupineMixin.java
+++ b/src/main/java/dev/hybridlabs/aquatic/mixin/PlayerEntityPorcupineMixin.java
@@ -10,6 +10,10 @@ import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,7 +22,9 @@ import java.util.List;
 @Mixin(PlayerEntity.class)
 public abstract class PlayerEntityPorcupineMixin extends LivingEntity implements Porcupine {
 
+    @Unique
     List<ItemStack> impaledStacks = new ArrayList<>();
+    @Unique
     private static final String IMPALED_ITEM_KEY = "impaled_items";
 
     protected PlayerEntityPorcupineMixin(EntityType<? extends LivingEntity> entityType, World world) {
@@ -29,14 +35,12 @@ public abstract class PlayerEntityPorcupineMixin extends LivingEntity implements
      * Get stacks currently impaled in player
      * @return immutable list of stacks within player
      */
-    @Override
+    @Unique
     public List<ItemStack> hybrid_aquatic$getImpaledStacks() {
         return Collections.unmodifiableList(impaledStacks);
     }
-
-    @Override
-    public void readCustomDataFromNbt(NbtCompound nbt) {
-        super.readCustomDataFromNbt(nbt);
+    @Inject( method="readCustomDataFromNbt", at=@At("TAIL") )
+    public void inject$readCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
         impaledStacks.clear();
 
         // Check if list exists, otherwise we're going to have issues.
@@ -50,9 +54,8 @@ public abstract class PlayerEntityPorcupineMixin extends LivingEntity implements
         }
     }
 
-    @Override
-    public void writeCustomDataToNbt(NbtCompound nbt) {
-        super.writeCustomDataToNbt(nbt);
+    @Inject( method="writeCustomDataToNbt", at=@At("TAIL") )
+    public void writeCustomDataToNbt(NbtCompound nbt, CallbackInfo ci) {
 
         if (!impaledStacks.isEmpty()) {
             var list = new NbtList();


### PR DESCRIPTION
Overriding PlayerEntity.readCustomDataFromNBT and PlayerEntity.writeCustomDataToNBT was preventing normal player data from being saved. This changes the mixin to use Inject at TAIL instead.