### PR TITLE
Adds config options for trade additions

### DIFF
--- a/common/src/main/kotlin/dev/hybridlabs/aquatic/config/HybridAquaticConfig.kt
+++ b/common/src/main/kotlin/dev/hybridlabs/aquatic/config/HybridAquaticConfig.kt
@@ -10,12 +10,18 @@ data class HybridAquaticConfig(
      */
     val dataVersion: Int = 7,
 
+
+
     val entitySpawnConfig: List<EntitySpawnConfig> = EntitySpawnConfigGenerator.generate(),
+    val enableWanderingTraderTrades: Boolean = true,
+    val enableVillagerTrades: Boolean = true,
 ) {
     companion object {
         val CODEC: Codec<HybridAquaticConfig> = RecordCodecBuilder.create { instance ->
             instance.group(
                 Codec.INT.fieldOf("data_version").forGetter(HybridAquaticConfig::dataVersion),
+                Codec.BOOL.fieldOf("enable_wandering_trader_trades").forGetter(HybridAquaticConfig::enableWanderingTraderTrades),
+                Codec.BOOL.fieldOf("enable_villager_trades").forGetter(HybridAquaticConfig::enableVillagerTrades),
                 EntitySpawnConfig.CODEC.listOf().fieldOf("spawn_configuration").forGetter(HybridAquaticConfig::entitySpawnConfig),
             ).apply(instance, ::HybridAquaticConfig)
         }

--- a/fabric/src/main/kotlin/dev/hybridlabs/aquatic/HybridAquatic.kt
+++ b/fabric/src/main/kotlin/dev/hybridlabs/aquatic/HybridAquatic.kt
@@ -81,12 +81,16 @@ object HybridAquatic : ModInitializer {
 
 
         registerDynamicRegistries()
-        registerWanderingTraderTrades()
-        registerCustomTrades()
+        val configHandler = ConfigHelper.initializeConfig(CommonClass.CONFIG_FILE)
+        if (configHandler.config.enableWanderingTraderTrades) {
+            registerWanderingTraderTrades()
+        }
+        if (configHandler.config.enableWanderingTraderTrades) {
+            registerCustomTrades()
+        }
         registerFlammables(FlammableBlockRegistry.getDefaultInstance())
         registerStrippables()
 
-        val configHandler = ConfigHelper.initializeConfig(CommonClass.CONFIG_FILE)
         registerBiomeModifications(configHandler.config)
 
         SERVER_STARTING.register { server ->


### PR DESCRIPTION
Adds two new boolean variables to the config for registering WanderingTraderTrades and CustomTrades (I assume villager trades). Both are set to true per default to keep the basic behaviour in tact.

I did not build and test it, as I am not familiar with the gradle and kotlin. Would appreciate help with that to not break stuff.