### PR TITLE
Add config options for Wantering Trader and Villager trades additions

### DIFF
--- a/common/src/main/kotlin/dev/hybridlabs/aquatic/config/HybridAquaticConfig.kt
+++ b/common/src/main/kotlin/dev/hybridlabs/aquatic/config/HybridAquaticConfig.kt
@@ -10,12 +10,18 @@ data class HybridAquaticConfig(
      */
     val dataVersion: Int = 7,
 
+
+
     val entitySpawnConfig: List<EntitySpawnConfig> = EntitySpawnConfigGenerator.generate(),
+    val enableWanderingTraderTrades: Boolean = true,
+    val enableVillagerTrades: Boolean = true,
 ) {
     companion object {
         val CODEC: Codec<HybridAquaticConfig> = RecordCodecBuilder.create { instance ->
             instance.group(
                 Codec.INT.fieldOf("data_version").forGetter(HybridAquaticConfig::dataVersion),
+                Codec.BOOL.fieldOf("enable_wandering_trader_trades").forGetter(HybridAquaticConfig::enableWanderingTraderTrades),
+                Codec.BOOL.fieldOf("enable_villager_trades").forGetter(HybridAquaticConfig::enableVillagerTrades),
                 EntitySpawnConfig.CODEC.listOf().fieldOf("spawn_configuration").forGetter(HybridAquaticConfig::entitySpawnConfig),
             ).apply(instance, ::HybridAquaticConfig)
         }

--- a/common/src/main/kotlin/dev/hybridlabs/aquatic/config/HybridAquaticConfig.kt
+++ b/common/src/main/kotlin/dev/hybridlabs/aquatic/config/HybridAquaticConfig.kt
@@ -9,12 +9,10 @@ data class HybridAquaticConfig(
      * Increase when the config needs to be reset, i.e. when new entity spawn configs are added.
      */
     val dataVersion: Int = 7,
-
-
-
-    val entitySpawnConfig: List<EntitySpawnConfig> = EntitySpawnConfigGenerator.generate(),
     val enableWanderingTraderTrades: Boolean = true,
     val enableVillagerTrades: Boolean = true,
+
+    val entitySpawnConfig: List<EntitySpawnConfig> = EntitySpawnConfigGenerator.generate(),
 ) {
     companion object {
         val CODEC: Codec<HybridAquaticConfig> = RecordCodecBuilder.create { instance ->

--- a/fabric/src/main/kotlin/dev/hybridlabs/aquatic/HybridAquatic.kt
+++ b/fabric/src/main/kotlin/dev/hybridlabs/aquatic/HybridAquatic.kt
@@ -81,12 +81,16 @@ object HybridAquatic : ModInitializer {
 
 
         registerDynamicRegistries()
-        registerWanderingTraderTrades()
-        registerCustomTrades()
+        val configHandler = ConfigHelper.initializeConfig(CommonClass.CONFIG_FILE)
+        if (configHandler.config.enableWanderingTraderTrades) {
+            registerWanderingTraderTrades()
+        }
+        if (configHandler.config.enableWanderingTraderTrades) {
+            registerCustomTrades()
+        }
         registerFlammables(FlammableBlockRegistry.getDefaultInstance())
         registerStrippables()
 
-        val configHandler = ConfigHelper.initializeConfig(CommonClass.CONFIG_FILE)
         registerBiomeModifications(configHandler.config)
 
         SERVER_STARTING.register { server ->


### PR DESCRIPTION
This additional configuration allows players and mod pack makers to disable the mod's changes  to trade tables.
Default values are set to "true" to allow the mod to ingest trades as before.

https://github.com/hybridlabs/hybrid-aquatic/issues/92